### PR TITLE
Add chargeable gadget system (Airstrike, Dash, Dice) integrated with …

### DIFF
--- a/Assets/Scripts/airstrike_bomb.gd
+++ b/Assets/Scripts/airstrike_bomb.gd
@@ -1,0 +1,60 @@
+class_name AirstrikeBomb
+extends Node2D
+
+## A single bomb dropped by the Airstrike gadget. It falls from above and
+## detonates on reaching its target height, dealing area damage to players
+## and destroying any destructibles caught in the blast radius.
+
+const BOMB_TEXTURE: Texture2D = preload("res://Assets/Sprites/weapons/ammo/shotgun/shell_full.png")
+
+@export var fall_speed: float = 700.0
+@export var damage: int = 35
+@export var blast_radius: float = 46.0
+
+var target_y: float = 0.0
+var source: Node = null
+
+var _exploded: bool = false
+
+
+func _ready() -> void:
+	var sprite := Sprite2D.new()
+	sprite.texture = BOMB_TEXTURE
+	sprite.scale = Vector2(2.0, 2.0)
+	add_child(sprite)
+
+
+func _physics_process(delta: float) -> void:
+	if _exploded:
+		return
+	position.y += fall_speed * delta
+	rotation += delta * 6.0
+	if global_position.y >= target_y:
+		_explode()
+
+
+func _explode() -> void:
+	_exploded = true
+
+	var scene := get_tree().current_scene
+	if scene:
+		var v := VfxBurst.new()
+		v.setup(Color(1.0, 0.55, 0.15), blast_radius * 1.7, 0.4)
+		scene.add_child(v)
+		v.global_position = global_position
+
+	for player in get_tree().get_nodes_in_group("Players"):
+		if not is_instance_valid(player):
+			continue
+		if global_position.distance_to(player.global_position) <= blast_radius:
+			if player.has_method("take_damage"):
+				player.take_damage(damage)
+
+	for obj in get_tree().get_nodes_in_group("Destructibles"):
+		if not is_instance_valid(obj):
+			continue
+		if global_position.distance_to(obj.global_position) <= blast_radius:
+			if obj.has_method("detonate"):
+				obj.detonate()
+
+	queue_free()

--- a/Assets/Scripts/airstrike_bomb.gd.uid
+++ b/Assets/Scripts/airstrike_bomb.gd.uid
@@ -1,0 +1,1 @@
+uid://iddy23cnx6v3

--- a/Assets/Scripts/character.gd
+++ b/Assets/Scripts/character.gd
@@ -19,6 +19,53 @@ signal health_changed(new_health: int, max_health: int)
 signal weapon_changed(slot: int)
 signal weapon_hud_changed(state: Dictionary)
 
+# --- Gadgets (chargeable abilities, separate from the weapon hotbar) ---
+const GADGET_AIRSTRIKE: int = 0
+const GADGET_DASH: int = 1
+const GADGET_DICE: int = 2
+const GADGET_NAMES: Array[String] = ["Airstrike", "Dash", "Dice"]
+const GADGET_VOICELINES: Dictionary = {
+	"Airstrike": "The Missile Knows where it is because it knows where it isn't",
+	"Dash": "Weeeeeeeeeeee",
+	"Dice": "Surprise! You're Dead.",
+}
+# Dice has its OWN pool of effects. Weighted so strong outcomes are rarer.
+const DICE_OUTCOMES: Array[String] = ["Heal", "Teleport", "Shockwave", "Swap", "Jackpot", "Snake Eyes"]
+const DICE_WEIGHTS: Array[int] = [2, 3, 3, 4, 1, 6]
+const DICE_VOICELINES: Dictionary = {
+	"Heal": "Patched up!",
+	"Teleport": "Now you see me...",
+	"Shockwave": "Get baaack!",
+	"Swap": "Let's trade places!",
+	"Jackpot": "Surprise! You're Dead.",
+	"Snake Eyes": "Ouch... bad luck.",
+}
+
+@export var gadget_max_charge: int = 100
+@export var gadget_charge_rate: float = 8.0
+@export var airstrike_bomb_count: int = 6
+@export var airstrike_spread: float = 150.0
+@export var dash_speed: float = 900.0
+@export var dash_duration: float = 0.18
+@export var shockwave_radius: float = 160.0
+@export var shockwave_damage: int = 30
+@export var shockwave_force: float = 650.0
+@export var snake_eyes_damage: int = 25
+
+var gadget_charge: int = 0
+var _charge_accum: float = 0.0
+var current_gadget: int = GADGET_AIRSTRIKE
+var _dice_result: int = -1
+var _dash_time_left: float = 0.0
+var _dash_dir: float = 1.0
+var _invulnerable: bool = false
+
+signal gadget_charge_changed(charge: int, max_charge: int)
+signal gadget_selected(gadget_name: String)
+signal gadget_used(gadget_name: String, voiceline: String)
+signal gadget_use_denied()
+signal dice_rolled(result_name: String)
+
 var _gravity: float = ProjectSettings.get_setting("physics/2d/default_gravity")
 var _sprite: AnimatedSprite2D
 var originalPosX: float
@@ -53,6 +100,8 @@ func _ready() -> void:
 	_footstep_player.bus = "SFX"
 	_sprite.play("idle")
 	_set_active_weapon(_shotgun)
+	gadget_charge_changed.emit(gadget_charge, gadget_max_charge)
+	gadget_selected.emit(get_gadget_name())
 
 
 func _input(event: InputEvent) -> void:
@@ -69,8 +118,30 @@ func _input(event: InputEvent) -> void:
 		_set_active_weapon(_knife)
 
 
+func _unhandled_input(event: InputEvent) -> void:
+	# Gadget controls (Q = use, G = cycle). Weapon slots use 1-9, reload uses R.
+	if _is_dead:
+		return
+	if event is InputEventKey and event.pressed and not event.echo:
+		if event.keycode == KEY_G:
+			_select_gadget((current_gadget + 1) % GADGET_NAMES.size())
+		elif event.keycode == KEY_Q:
+			_try_use_gadget()
+
+
 func _physics_process(delta: float) -> void:
 	var vel: Vector2 = velocity
+
+	# Dash gadget: brief invulnerable horizontal burst that dodges shots.
+	if _dash_time_left > 0.0:
+		_dash_time_left -= delta
+		vel.x = _dash_dir * dash_speed
+		vel.y = 0.0
+		velocity = vel
+		move_and_slide()
+		if _dash_time_left <= 0.0:
+			_invulnerable = false
+		return
 
 	if not is_on_floor():
 		vel.y += _gravity * delta
@@ -106,6 +177,8 @@ func _physics_process(delta: float) -> void:
 		if collider.is_in_group("Destructibles") and velocity.y < 0:
 			collider.detonate()
 			velocity.y = bounce_impulse
+
+	_update_gadget_charge(delta)
 
 
 func _update_animation(is_moving: bool) -> void:
@@ -148,7 +221,7 @@ func _play_jump_sound() -> void:
 
 
 func take_damage(amount: int) -> void:
-	if _is_dead:
+	if _is_dead or _invulnerable:
 		return
 	current_health = clamp(current_health - amount, 0, max_health)
 	health_changed.emit(current_health, max_health)
@@ -176,6 +249,8 @@ func _respawn() -> void:
 	current_health = max_health
 	health_changed.emit(current_health, max_health)
 	velocity = Vector2.ZERO
+	_dash_time_left = 0.0
+	_invulnerable = false
 	set_physics_process(true)
 	if _footstep_player:
 		_footstep_player.stop()
@@ -249,3 +324,180 @@ func get_active_weapon_hud_state() -> Dictionary:
 	return {
 		"visible": false,
 	}
+
+
+# ---------------------------------------------------------------------------
+# Gadgets
+# ---------------------------------------------------------------------------
+
+func get_gadget_name() -> String:
+	return GADGET_NAMES[current_gadget]
+
+
+func _update_gadget_charge(delta: float) -> void:
+	if gadget_charge >= gadget_max_charge:
+		return
+	_charge_accum += gadget_charge_rate * delta
+	var new_charge: int = min(gadget_max_charge, int(_charge_accum))
+	if new_charge != gadget_charge:
+		gadget_charge = new_charge
+		gadget_charge_changed.emit(gadget_charge, gadget_max_charge)
+		if gadget_charge >= gadget_max_charge and current_gadget == GADGET_DICE and _dice_result == -1:
+			_roll_dice()
+
+
+func _select_gadget(index: int) -> void:
+	if index == current_gadget:
+		return
+	current_gadget = index
+	gadget_selected.emit(get_gadget_name())
+	# Roll Dice once when selected-while-charged; a previous roll is kept
+	# (you can't re-roll by switching away and back — only using clears it).
+	if current_gadget == GADGET_DICE and gadget_charge >= gadget_max_charge and _dice_result == -1:
+		_roll_dice()
+
+
+func _roll_dice() -> void:
+	_dice_result = _weighted_dice()
+	dice_rolled.emit(DICE_OUTCOMES[_dice_result])
+
+
+func _weighted_dice() -> int:
+	var total: int = 0
+	for w in DICE_WEIGHTS:
+		total += w
+	var pick: int = randi() % total
+	var acc: int = 0
+	for i in DICE_WEIGHTS.size():
+		acc += DICE_WEIGHTS[i]
+		if pick < acc:
+			return i
+	return DICE_WEIGHTS.size() - 1
+
+
+func _try_use_gadget() -> void:
+	if gadget_charge < gadget_max_charge:
+		gadget_use_denied.emit()
+		return
+
+	match current_gadget:
+		GADGET_AIRSTRIKE:
+			_gadget_airstrike(get_global_mouse_position())
+			gadget_used.emit("Airstrike", GADGET_VOICELINES["Airstrike"])
+		GADGET_DASH:
+			_gadget_dash()
+			gadget_used.emit("Dash", GADGET_VOICELINES["Dash"])
+		GADGET_DICE:
+			_use_dice()
+
+	gadget_charge = 0
+	_charge_accum = 0.0
+	_dice_result = -1
+	gadget_charge_changed.emit(gadget_charge, gadget_max_charge)
+
+
+func _spawn_vfx(pos: Vector2, color: Color, radius: float, dur: float = 0.35) -> void:
+	var scene := get_tree().current_scene
+	if scene == null:
+		return
+	var v := VfxBurst.new()
+	v.setup(color, radius, dur)
+	scene.add_child(v)
+	v.global_position = pos
+
+
+func _gadget_dash() -> void:
+	_dash_dir = -1.0 if facing_left else 1.0
+	_dash_time_left = dash_duration
+	_invulnerable = true
+	_spawn_vfx(global_position, Color(0.85, 0.92, 1.0), 38.0, 0.3)
+
+
+func _gadget_airstrike(center: Vector2) -> void:
+	for i in range(airstrike_bomb_count):
+		var t: float = float(i) / float(max(1, airstrike_bomb_count - 1))
+		var x: float = center.x - airstrike_spread * 0.5 + airstrike_spread * t
+		await get_tree().create_timer(0.08 * i).timeout
+		if not is_inside_tree():
+			return
+		var bomb := AirstrikeBomb.new()
+		bomb.target_y = center.y
+		get_tree().current_scene.add_child(bomb)
+		bomb.global_position = Vector2(x, center.y - 360.0)
+
+
+func _other_players() -> Array:
+	var list: Array = []
+	for player in get_tree().get_nodes_in_group("Players"):
+		if player != self and is_instance_valid(player) and not player._is_dead:
+			list.append(player)
+	return list
+
+
+func _use_dice() -> void:
+	var idx: int = _dice_result if _dice_result != -1 else _weighted_dice()
+	var outcome: String = DICE_OUTCOMES[idx]
+	match idx:
+		0:
+			_dice_heal()
+		1:
+			_dice_teleport()
+		2:
+			_dice_shockwave()
+		3:
+			_dice_swap()
+		4:
+			_dice_jackpot()
+		5:
+			_dice_snake_eyes()
+	gadget_used.emit("Dice → %s" % outcome, DICE_VOICELINES.get(outcome, GADGET_VOICELINES["Dice"]))
+
+
+func _dice_heal() -> void:
+	current_health = max_health
+	health_changed.emit(current_health, max_health)
+	_spawn_vfx(global_position, Color(0.3, 0.85, 0.4), 44.0, 0.45)
+
+
+func _dice_teleport() -> void:
+	_spawn_vfx(global_position, Color(0.6, 0.45, 0.95), 40.0, 0.35)
+	global_position = get_global_mouse_position()
+	velocity = Vector2.ZERO
+	_spawn_vfx(global_position, Color(0.6, 0.45, 0.95), 40.0, 0.35)
+
+
+func _dice_shockwave() -> void:
+	_spawn_vfx(global_position, Color(0.4, 0.85, 1.0), shockwave_radius, 0.4)
+	for other in _other_players():
+		if global_position.distance_to(other.global_position) <= shockwave_radius:
+			var dir: Vector2 = (other.global_position - global_position).normalized()
+			if dir == Vector2.ZERO:
+				dir = Vector2.RIGHT
+			other.velocity = dir * shockwave_force + Vector2.UP * shockwave_force * 0.4
+			if other.has_method("take_damage"):
+				other.take_damage(shockwave_damage)
+
+
+func _dice_swap() -> void:
+	var others := _other_players()
+	if others.size() > 0:
+		var target = others[randi() % others.size()]
+		var tmp := global_position
+		_spawn_vfx(global_position, Color(0.95, 0.6, 0.2), 38.0, 0.35)
+		global_position = target.global_position
+		target.global_position = tmp
+		_spawn_vfx(global_position, Color(0.95, 0.6, 0.2), 38.0, 0.35)
+		_spawn_vfx(tmp, Color(0.95, 0.6, 0.2), 38.0, 0.35)
+
+
+func _dice_jackpot() -> void:
+	var others := _other_players()
+	if others.size() > 0:
+		var victim = others[randi() % others.size()]
+		_spawn_vfx(victim.global_position, Color(0.95, 0.25, 0.22), 50.0, 0.45)
+		victim.die()
+
+
+func _dice_snake_eyes() -> void:
+	_spawn_vfx(global_position, Color(0.9, 0.3, 0.28), 34.0, 0.35)
+	take_damage(snake_eyes_damage)

--- a/Assets/Scripts/gadget_icon.gd
+++ b/Assets/Scripts/gadget_icon.gd
@@ -1,0 +1,135 @@
+class_name GadgetIcon
+extends Control
+
+## Draws a simple, crisp gadget/outcome glyph entirely in code so it scales
+## cleanly and needs no image assets.
+## 0 Airstrike  1 Dash  2 Dice  3 Heal  4 Teleport  5 Shockwave
+## 6 Swap  7 Jackpot  8 Snake Eyes
+
+@export var gadget: int = 0
+var icon_color: Color = Color(0.92, 0.94, 1.0)
+
+
+func set_gadget(g: int) -> void:
+	gadget = g
+	queue_redraw()
+
+
+func set_icon_color(c: Color) -> void:
+	icon_color = c
+	queue_redraw()
+
+
+func _draw() -> void:
+	var c := Vector2(size.x * 0.5, size.y * 0.5)
+	var u: float = min(size.x, size.y)
+	match gadget:
+		0:
+			_draw_airstrike(c, u)
+		1:
+			_draw_dash(c, u)
+		2:
+			_draw_dice(c, u)
+		3:
+			_draw_heal(c, u)
+		4:
+			_draw_teleport(c, u)
+		5:
+			_draw_shockwave(c, u)
+		6:
+			_draw_swap(c, u)
+		7:
+			_draw_jackpot(c, u)
+		8:
+			_draw_snake_eyes(c, u)
+
+
+func _draw_airstrike(c: Vector2, u: float) -> void:
+	var w: float = u * 0.16
+	var body := Vector2(c.x, c.y + u * 0.04)
+	draw_circle(body, w, icon_color)
+	draw_colored_polygon(PackedVector2Array([
+		Vector2(body.x - w, body.y), Vector2(body.x + w, body.y),
+		Vector2(body.x, body.y + u * 0.24)]), icon_color)
+	draw_colored_polygon(PackedVector2Array([
+		Vector2(c.x - w, c.y - u * 0.20), Vector2(c.x, c.y - u * 0.10),
+		Vector2(c.x + w, c.y - u * 0.20), Vector2(c.x, c.y - u * 0.30)]), icon_color)
+	var lw: float = max(2.0, u * 0.04)
+	draw_line(Vector2(c.x - w * 2.4, c.y - u * 0.22), Vector2(c.x - w * 2.4, c.y - u * 0.02), icon_color, lw)
+	draw_line(Vector2(c.x + w * 2.4, c.y - u * 0.22), Vector2(c.x + w * 2.4, c.y - u * 0.02), icon_color, lw)
+
+
+func _draw_dash(c: Vector2, u: float) -> void:
+	var hw: float = u * 0.16
+	var hh: float = u * 0.22
+	var th: float = max(3.0, u * 0.09)
+	for off in [-hw * 0.9, hw * 0.5]:
+		draw_polyline(PackedVector2Array([
+			Vector2(c.x + off - hw * 0.5, c.y - hh),
+			Vector2(c.x + off + hw * 0.5, c.y),
+			Vector2(c.x + off - hw * 0.5, c.y + hh)]), icon_color, th)
+
+
+func _draw_dice(c: Vector2, u: float) -> void:
+	var d: float = u * 0.56
+	draw_rect(Rect2(c.x - d * 0.5, c.y - d * 0.5, d, d), icon_color, false, max(3.0, d * 0.10))
+	var pr: float = d * 0.10
+	var o: float = d * 0.26
+	for p in [Vector2(-o, -o), Vector2(o, -o), Vector2.ZERO, Vector2(-o, o), Vector2(o, o)]:
+		draw_circle(c + p, pr, icon_color)
+
+
+func _draw_heal(c: Vector2, u: float) -> void:
+	var t: float = u * 0.14
+	var l: float = u * 0.30
+	draw_rect(Rect2(c.x - t, c.y - l, t * 2.0, l * 2.0), icon_color)
+	draw_rect(Rect2(c.x - l, c.y - t, l * 2.0, t * 2.0), icon_color)
+
+
+func _draw_teleport(c: Vector2, u: float) -> void:
+	var w: float = max(2.0, u * 0.07)
+	draw_arc(c, u * 0.30, deg_to_rad(40), deg_to_rad(320), 28, icon_color, w, true)
+	draw_arc(c, u * 0.17, deg_to_rad(220), deg_to_rad(120), 24, icon_color, w, true)
+	draw_circle(c, u * 0.05, icon_color)
+
+
+func _draw_shockwave(c: Vector2, u: float) -> void:
+	var w: float = max(2.0, u * 0.06)
+	draw_arc(c, u * 0.14, 0.0, TAU, 24, icon_color, w, true)
+	draw_arc(c, u * 0.26, 0.0, TAU, 28, icon_color, w, true)
+	draw_arc(c, u * 0.38, 0.0, TAU, 32, icon_color, w, true)
+
+
+func _draw_swap(c: Vector2, u: float) -> void:
+	var w: float = max(3.0, u * 0.08)
+	var y1: float = c.y - u * 0.15
+	var y2: float = c.y + u * 0.15
+	var xl: float = c.x - u * 0.28
+	var xr: float = c.x + u * 0.28
+	draw_line(Vector2(xl, y1), Vector2(xr, y1), icon_color, w)
+	draw_polyline(PackedVector2Array([
+		Vector2(xr - u * 0.12, y1 - u * 0.10), Vector2(xr, y1),
+		Vector2(xr - u * 0.12, y1 + u * 0.10)]), icon_color, w)
+	draw_line(Vector2(xr, y2), Vector2(xl, y2), icon_color, w)
+	draw_polyline(PackedVector2Array([
+		Vector2(xl + u * 0.12, y2 - u * 0.10), Vector2(xl, y2),
+		Vector2(xl + u * 0.12, y2 + u * 0.10)]), icon_color, w)
+
+
+func _draw_jackpot(c: Vector2, u: float) -> void:
+	var pts := PackedVector2Array()
+	var outer: float = u * 0.38
+	var inner: float = u * 0.16
+	for i in range(10):
+		var ang: float = -PI * 0.5 + float(i) * PI / 5.0
+		var rad: float = outer if i % 2 == 0 else inner
+		pts.append(c + Vector2(cos(ang), sin(ang)) * rad)
+	draw_colored_polygon(pts, icon_color)
+
+
+func _draw_snake_eyes(c: Vector2, u: float) -> void:
+	var d: float = u * 0.52
+	draw_rect(Rect2(c.x - d * 0.5, c.y - d * 0.5, d, d), icon_color, false, max(3.0, d * 0.10))
+	var pr: float = d * 0.13
+	draw_circle(c + Vector2(-d * 0.22, -d * 0.22), pr, icon_color)
+	draw_circle(c + Vector2(d * 0.22, d * 0.22), pr, icon_color)

--- a/Assets/Scripts/gadget_icon.gd.uid
+++ b/Assets/Scripts/gadget_icon.gd.uid
@@ -1,0 +1,1 @@
+uid://7oi4bsol1fsk

--- a/Assets/Scripts/hud.gd
+++ b/Assets/Scripts/hud.gd
@@ -18,8 +18,67 @@ extends CanvasLayer
 	$Hotbar/PanelContainer/HBoxContainer/Slot9,
 ]
 
+# Gadget HUD (bottom-right, clear of the centered hotbar and top-left health)
+@onready var gadget_widget: Control = $GadgetWidget
+@onready var gadget_frame: Panel = $GadgetWidget/Frame
+@onready var charge_bar: ProgressBar = $GadgetWidget/Frame/ChargeFill
+@onready var gadget_icon: Control = $GadgetWidget/Frame/Icon
+@onready var reel: Control = $GadgetWidget/Frame/Reel
+@onready var reel_strip: Control = $GadgetWidget/Frame/Reel/Strip
+@onready var die_badge: Control = $GadgetWidget/DieBadge
+@onready var key_hint: Panel = $GadgetWidget/KeyHint
+@onready var name_label: Label = $GadgetWidget/NameLabel
+@onready var voiceline_label: Label = $VoicelineLabel
+@onready var sel_icons: Array = [
+	$GadgetWidget/Selector/Sel0,
+	$GadgetWidget/Selector/Sel1,
+	$GadgetWidget/Selector/Sel2,
+]
+
+const GADGET_ORDER := {"Airstrike": 0, "Dash": 1, "Dice": 2}
+const DICE_LABELS := ["Heal", "Teleport", "Shockwave", "Swap", "Jackpot", "Snake Eyes"]
+const DICE_ICON := {"Heal": 3, "Teleport": 4, "Shockwave": 5, "Swap": 6, "Jackpot": 7, "Snake Eyes": 8}
+
+const FILL_CHARGING := Color(0.88, 0.28, 0.23, 0.55)
+const FILL_READY := Color(0.96, 0.74, 0.12, 0.8)
+const BORDER_IDLE := Color(0.32, 0.36, 0.45, 1.0)
+const BORDER_READY := Color(0.96, 0.74, 0.12, 1.0)
+const BORDER_READY_HI := Color(1.0, 0.95, 0.65, 1.0)
+const BORDER_DENIED := Color(0.9, 0.25, 0.22, 1.0)
+const ICON_IDLE := Color(0.92, 0.94, 1.0)
+const ICON_READY := Color(1.0, 0.97, 0.85)
+const SEL_ACTIVE := Color(0.96, 0.74, 0.12)
+const SEL_INACTIVE := Color(0.55, 0.6, 0.7)
+
 var _player: CharacterBody2D
 var _ghost_tween: Tween
+var _pulse_tween: Tween
+var _voiceline_tween: Tween
+var _flash_tween: Tween
+var _roll_tween: Tween
+var _fill_style: StyleBoxFlat
+var _frame_style: StyleBoxFlat
+var _is_ready := false
+var _dice_result_name := ""
+var _current_name := ""
+
+
+func _ready() -> void:
+	var fill := charge_bar.get_theme_stylebox("fill")
+	if fill is StyleBoxFlat:
+		_fill_style = fill
+		_fill_style.bg_color = FILL_CHARGING
+	var frame := gadget_frame.get_theme_stylebox("panel")
+	if frame is StyleBoxFlat:
+		_frame_style = frame
+		_frame_style.border_color = BORDER_IDLE
+	if gadget_icon.has_method("set_icon_color"):
+		gadget_icon.set_icon_color(ICON_IDLE)
+	key_hint.visible = false
+	die_badge.visible = false
+	reel.visible = false
+	voiceline_label.modulate.a = 0.0
+	_update_selector(0)
 
 
 func connect_to_player(player: CharacterBody2D) -> void:
@@ -36,6 +95,18 @@ func connect_to_player(player: CharacterBody2D) -> void:
 	_set_active_slot(1)
 	if player.has_method("get_active_weapon_hud_state"):
 		_on_weapon_hud_changed(player.get_active_weapon_hud_state())
+
+	# Gadgets
+	if player.has_signal("gadget_charge_changed"):
+		charge_bar.max_value = player.gadget_max_charge
+		charge_bar.value = player.gadget_charge
+		_apply_gadget(player.get_gadget_name())
+		player.gadget_charge_changed.connect(_on_gadget_charge_changed)
+		player.gadget_selected.connect(_on_gadget_selected)
+		player.gadget_used.connect(_on_gadget_used)
+		player.gadget_use_denied.connect(_on_gadget_use_denied)
+		player.dice_rolled.connect(_on_dice_rolled)
+
 
 func _on_health_changed(new_health: int, max_health: int) -> void:
 	health_bar.max_value = max_health
@@ -118,6 +189,198 @@ func _clear_ammo_icons() -> void:
 	for child in ammo_icons.get_children():
 		ammo_icons.remove_child(child)
 		child.free()
+
+
+# ---------------------------------------------------------------------------
+# Gadget HUD
+# ---------------------------------------------------------------------------
+
+func _on_gadget_charge_changed(charge: int, max_charge: int) -> void:
+	charge_bar.max_value = max_charge
+	charge_bar.value = charge
+	var full := charge >= max_charge
+	if full and not _is_ready:
+		_set_ready(true)
+	elif not full and _is_ready:
+		_set_ready(false)
+
+
+func _set_ready(ready: bool) -> void:
+	_is_ready = ready
+	if _pulse_tween:
+		_pulse_tween.kill()
+
+	if ready:
+		if _fill_style:
+			_fill_style.bg_color = FILL_READY
+		if gadget_icon.has_method("set_icon_color"):
+			gadget_icon.set_icon_color(ICON_READY)
+		key_hint.visible = true
+		key_hint.modulate.a = 1.0
+		_punch(gadget_widget, 1.2)
+		_pulse_tween = create_tween().set_loops()
+		if _frame_style:
+			_pulse_tween.tween_property(_frame_style, "border_color", BORDER_READY_HI, 0.5).set_trans(Tween.TRANS_SINE)
+		_pulse_tween.parallel().tween_property(key_hint, "modulate:a", 0.5, 0.5)
+		if _frame_style:
+			_pulse_tween.tween_property(_frame_style, "border_color", BORDER_READY, 0.5).set_trans(Tween.TRANS_SINE)
+		_pulse_tween.parallel().tween_property(key_hint, "modulate:a", 1.0, 0.5)
+	else:
+		if _fill_style:
+			_fill_style.bg_color = FILL_CHARGING
+		if _frame_style:
+			_frame_style.border_color = BORDER_IDLE
+		key_hint.visible = false
+		die_badge.visible = false
+		if _current_name == "Dice":
+			if gadget_icon.has_method("set_gadget"):
+				gadget_icon.set_gadget(2)
+			name_label.text = "Dice"
+		if gadget_icon.has_method("set_icon_color"):
+			gadget_icon.set_icon_color(ICON_IDLE)
+
+
+func _apply_gadget(gadget_name: String) -> void:
+	_current_name = gadget_name
+	var idx: int = GADGET_ORDER.get(gadget_name, 0)
+	if gadget_name == "Dice" and _dice_result_name != "":
+		die_badge.visible = true
+		if gadget_icon.has_method("set_gadget"):
+			gadget_icon.set_gadget(DICE_ICON.get(_dice_result_name, 2))
+		if gadget_icon.has_method("set_icon_color"):
+			gadget_icon.set_icon_color(_dice_color(_dice_result_name))
+		name_label.text = "Dice: %s" % _dice_result_name
+	else:
+		die_badge.visible = false
+		name_label.text = gadget_name
+		if gadget_icon.has_method("set_gadget"):
+			gadget_icon.set_gadget(idx)
+		if gadget_icon.has_method("set_icon_color"):
+			gadget_icon.set_icon_color(ICON_READY if _is_ready else ICON_IDLE)
+	_update_selector(idx)
+
+
+func _update_selector(active_idx: int) -> void:
+	for i in sel_icons.size():
+		var ic: Control = sel_icons[i]
+		var is_active: bool = i == active_idx
+		ic.pivot_offset = ic.size / 2.0
+		if ic.has_method("set_icon_color"):
+			ic.set_icon_color(SEL_ACTIVE if is_active else SEL_INACTIVE)
+		var t := create_tween()
+		t.parallel().tween_property(ic, "scale", Vector2.ONE * (1.25 if is_active else 0.85), 0.18).set_trans(Tween.TRANS_BACK).set_ease(Tween.EASE_OUT)
+		t.parallel().tween_property(ic, "modulate:a", 1.0 if is_active else 0.5, 0.18)
+
+
+func _on_gadget_selected(gadget_name: String) -> void:
+	_apply_gadget(gadget_name)
+	_punch(gadget_widget, 1.12)
+
+
+func _on_dice_rolled(result_name: String) -> void:
+	if _roll_tween:
+		_roll_tween.kill()
+	die_badge.visible = true
+	gadget_icon.visible = false
+	name_label.text = "Rolling..."
+	_build_reel(result_name)
+	reel.visible = true
+
+	var item_h: float = reel.size.y
+	var n: int = reel_strip.get_child_count()
+	reel_strip.position.y = -(n - 1) * item_h
+	_roll_tween = create_tween()
+	_roll_tween.tween_property(reel_strip, "position:y", 0.0, 1.2).set_trans(Tween.TRANS_CUBIC).set_ease(Tween.EASE_OUT)
+	_roll_tween.tween_callback(_finish_dice_roll.bind(result_name))
+
+
+func _build_reel(result_name: String) -> void:
+	for child in reel_strip.get_children():
+		child.queue_free()
+	var item_h: float = reel.size.y
+	var w: float = reel.size.x
+	var n := 14
+	for i in n:
+		var entry: String = result_name if i == 0 else DICE_LABELS[randi() % DICE_LABELS.size()]
+		var ic := GadgetIcon.new()
+		ic.set_gadget(DICE_ICON.get(entry, 2))
+		ic.set_icon_color(_dice_color(entry))
+		ic.position = Vector2(0, i * item_h)
+		ic.size = Vector2(w, item_h)
+		ic.mouse_filter = Control.MOUSE_FILTER_IGNORE
+		reel_strip.add_child(ic)
+
+
+func _dice_color(entry: String) -> Color:
+	match entry:
+		"Jackpot":
+			return Color(0.96, 0.74, 0.12)
+		"Heal":
+			return Color(0.3, 0.85, 0.4)
+		"Snake Eyes":
+			return Color(0.9, 0.3, 0.28)
+		_:
+			return Color(0.95, 0.96, 1.0)
+
+
+func _finish_dice_roll(result_name: String) -> void:
+	reel.visible = false
+	gadget_icon.visible = true
+	_dice_result_name = result_name
+	if gadget_icon.has_method("set_gadget"):
+		gadget_icon.set_gadget(DICE_ICON.get(result_name, 2))
+	if gadget_icon.has_method("set_icon_color"):
+		gadget_icon.set_icon_color(_dice_color(result_name))
+	name_label.text = "Dice: %s" % result_name
+	_punch(gadget_widget, 1.2)
+
+
+func _on_gadget_use_denied() -> void:
+	_shake(gadget_widget)
+	if _frame_style and not _is_ready:
+		if _flash_tween:
+			_flash_tween.kill()
+		_frame_style.border_color = BORDER_DENIED
+		_flash_tween = create_tween()
+		_flash_tween.tween_property(_frame_style, "border_color", BORDER_IDLE, 0.3)
+
+
+func _on_gadget_used(gadget_name: String, voiceline: String) -> void:
+	_dice_result_name = ""
+	voiceline_label.text = "%s — \"%s\"" % [gadget_name, voiceline]
+	voiceline_label.pivot_offset = voiceline_label.size / 2.0
+	_punch(gadget_widget, 1.12)
+
+	if _voiceline_tween:
+		_voiceline_tween.kill()
+	voiceline_label.modulate.a = 0.0
+	voiceline_label.scale = Vector2(0.85, 0.85)
+	voiceline_label.position.y = 30.0
+
+	_voiceline_tween = create_tween()
+	_voiceline_tween.parallel().tween_property(voiceline_label, "modulate:a", 1.0, 0.15)
+	_voiceline_tween.parallel().tween_property(voiceline_label, "scale", Vector2.ONE, 0.25).set_trans(Tween.TRANS_BACK).set_ease(Tween.EASE_OUT)
+	_voiceline_tween.parallel().tween_property(voiceline_label, "position:y", 40.0, 0.25).set_trans(Tween.TRANS_BACK).set_ease(Tween.EASE_OUT)
+	_voiceline_tween.tween_interval(1.8)
+	_voiceline_tween.parallel().tween_property(voiceline_label, "modulate:a", 0.0, 0.4)
+	_voiceline_tween.parallel().tween_property(voiceline_label, "position:y", 24.0, 0.4)
+
+
+func _punch(node: Control, amount: float = 1.12) -> void:
+	node.pivot_offset = node.size / 2.0
+	node.scale = Vector2(amount, amount)
+	var t := create_tween()
+	t.tween_property(node, "scale", Vector2.ONE, 0.22).set_trans(Tween.TRANS_BACK).set_ease(Tween.EASE_OUT)
+
+
+func _shake(node: Control) -> void:
+	node.pivot_offset = node.size / 2.0
+	var t := create_tween()
+	t.tween_property(node, "rotation", 0.10, 0.05)
+	t.tween_property(node, "rotation", -0.10, 0.05)
+	t.tween_property(node, "rotation", 0.06, 0.04)
+	t.tween_property(node, "rotation", 0.0, 0.04)
+
 
 func _on_take_damage_pressed() -> void:
 	if _player:

--- a/Assets/Scripts/vfx_burst.gd
+++ b/Assets/Scripts/vfx_burst.gd
@@ -1,0 +1,32 @@
+class_name VfxBurst
+extends Node2D
+
+## A short-lived, code-drawn burst: an expanding ring + inner flash that
+## fades out and frees itself. Used for explosions, shockwaves, teleports, etc.
+
+var color: Color = Color.WHITE
+var max_radius: float = 40.0
+var duration: float = 0.35
+var _t: float = 0.0
+
+
+func setup(c: Color, radius: float, dur: float = 0.35) -> void:
+	color = c
+	max_radius = radius
+	duration = dur
+
+
+func _process(delta: float) -> void:
+	_t += delta
+	queue_redraw()
+	if _t >= duration:
+		queue_free()
+
+
+func _draw() -> void:
+	var k: float = clampf(_t / duration, 0.0, 1.0)
+	var r: float = lerpf(max_radius * 0.25, max_radius, k)
+	var a: float = 1.0 - k
+	var ring := Color(color.r, color.g, color.b, a)
+	draw_arc(Vector2.ZERO, r, 0.0, TAU, 48, ring, maxf(2.0, 7.0 * (1.0 - k)), true)
+	draw_circle(Vector2.ZERO, r * 0.35, Color(color.r, color.g, color.b, a * 0.35))

--- a/Assets/Scripts/vfx_burst.gd.uid
+++ b/Assets/Scripts/vfx_burst.gd.uid
@@ -1,0 +1,1 @@
+uid://bllxxkq02btq6

--- a/src/scenes/hud.tscn
+++ b/src/scenes/hud.tscn
@@ -5,6 +5,7 @@
 [ext_resource type="Texture2D" path="res://Assets/Sprites/weapons/guns/sniper_old.png" id="3_sniper_icon"]
 [ext_resource type="Texture2D" path="res://Assets/Sprites/weapons/guns/shuriken.png" id="4_shuriken_icon"]
 [ext_resource type="Texture2D" path="res://Assets/Sprites/weapons/guns/knife.png" id="5_knife_icon"]
+[ext_resource type="Script" path="res://Assets/Scripts/gadget_icon.gd" id="6_gadget_icon"]
 
 [sub_resource type="StyleBoxFlat" id="StyleBoxFlat_fill_health"]
 bg_color = Color(0.2, 0.8, 0.2, 1)
@@ -30,6 +31,44 @@ corner_radius_bottom_right = 5
 [sub_resource type="StyleBoxFlat" id="StyleBoxFlat_bg_transparent"]
 bg_color = Color(0, 0, 0, 0)
 draw_center = false
+
+[sub_resource type="StyleBoxFlat" id="sb_gadget_frame"]
+bg_color = Color(0.09, 0.1, 0.16, 0.92)
+border_width_left = 3
+border_width_top = 3
+border_width_right = 3
+border_width_bottom = 3
+border_color = Color(0.32, 0.36, 0.45, 1)
+corner_radius_top_left = 16
+corner_radius_top_right = 16
+corner_radius_bottom_left = 16
+corner_radius_bottom_right = 16
+
+[sub_resource type="StyleBoxFlat" id="sb_gadget_charge"]
+bg_color = Color(0.88, 0.28, 0.23, 0.55)
+corner_radius_top_left = 12
+corner_radius_top_right = 12
+corner_radius_bottom_left = 12
+corner_radius_bottom_right = 12
+
+[sub_resource type="StyleBoxFlat" id="sb_gadget_keyhint"]
+bg_color = Color(0.96, 0.74, 0.12, 1)
+corner_radius_top_left = 8
+corner_radius_top_right = 8
+corner_radius_bottom_left = 8
+corner_radius_bottom_right = 8
+
+[sub_resource type="StyleBoxFlat" id="sb_gadget_badge"]
+bg_color = Color(0.09, 0.1, 0.16, 0.95)
+border_width_left = 2
+border_width_top = 2
+border_width_right = 2
+border_width_bottom = 2
+border_color = Color(0.96, 0.74, 0.12, 1)
+corner_radius_top_left = 8
+corner_radius_top_right = 8
+corner_radius_bottom_left = 8
+corner_radius_bottom_right = 8
 
 [node name="HUD" type="CanvasLayer"]
 script = ExtResource("1_hud")
@@ -252,5 +291,159 @@ horizontal_alignment = 1
 custom_minimum_size = Vector2(24, 24)
 expand_mode = 1
 stretch_mode = 5
+
+[node name="GadgetWidget" type="Control" parent="."]
+anchor_left = 1.0
+anchor_top = 1.0
+anchor_right = 1.0
+anchor_bottom = 1.0
+offset_left = -116.0
+offset_top = -176.0
+offset_right = -16.0
+offset_bottom = -22.0
+mouse_filter = 2
+
+[node name="Selector" type="Control" parent="GadgetWidget"]
+anchor_right = 1.0
+offset_bottom = 28.0
+mouse_filter = 2
+
+[node name="Sel0" type="Control" parent="GadgetWidget/Selector"]
+offset_left = 8.0
+offset_top = 2.0
+offset_right = 32.0
+offset_bottom = 26.0
+mouse_filter = 2
+script = ExtResource("6_gadget_icon")
+
+[node name="Sel1" type="Control" parent="GadgetWidget/Selector"]
+offset_left = 38.0
+offset_top = 2.0
+offset_right = 62.0
+offset_bottom = 26.0
+mouse_filter = 2
+script = ExtResource("6_gadget_icon")
+gadget = 1
+
+[node name="Sel2" type="Control" parent="GadgetWidget/Selector"]
+offset_left = 68.0
+offset_top = 2.0
+offset_right = 92.0
+offset_bottom = 26.0
+mouse_filter = 2
+script = ExtResource("6_gadget_icon")
+gadget = 2
+
+[node name="Frame" type="Panel" parent="GadgetWidget"]
+offset_left = 6.0
+offset_top = 34.0
+offset_right = 94.0
+offset_bottom = 122.0
+mouse_filter = 2
+theme_override_styles/panel = SubResource("sb_gadget_frame")
+
+[node name="ChargeFill" type="ProgressBar" parent="GadgetWidget/Frame"]
+anchor_right = 1.0
+anchor_bottom = 1.0
+offset_left = 4.0
+offset_top = 4.0
+offset_right = -4.0
+offset_bottom = -4.0
+mouse_filter = 2
+fill_mode = 3
+max_value = 100.0
+value = 0.0
+show_percentage = false
+theme_override_styles/fill = SubResource("sb_gadget_charge")
+theme_override_styles/background = SubResource("StyleBoxFlat_bg_transparent")
+
+[node name="Icon" type="Control" parent="GadgetWidget/Frame"]
+anchor_right = 1.0
+anchor_bottom = 1.0
+offset_left = 12.0
+offset_top = 12.0
+offset_right = -12.0
+offset_bottom = -12.0
+mouse_filter = 2
+script = ExtResource("6_gadget_icon")
+
+[node name="Reel" type="Control" parent="GadgetWidget/Frame"]
+visible = false
+clip_contents = true
+anchor_right = 1.0
+anchor_bottom = 1.0
+offset_left = 6.0
+offset_top = 6.0
+offset_right = -6.0
+offset_bottom = -6.0
+mouse_filter = 2
+
+[node name="Strip" type="Control" parent="GadgetWidget/Frame/Reel"]
+mouse_filter = 2
+
+[node name="DieBadge" type="Panel" parent="GadgetWidget"]
+visible = false
+offset_left = 4.0
+offset_top = 32.0
+offset_right = 30.0
+offset_bottom = 58.0
+mouse_filter = 2
+theme_override_styles/panel = SubResource("sb_gadget_badge")
+
+[node name="Icon" type="Control" parent="GadgetWidget/DieBadge"]
+anchor_right = 1.0
+anchor_bottom = 1.0
+offset_left = 4.0
+offset_top = 4.0
+offset_right = -4.0
+offset_bottom = -4.0
+mouse_filter = 2
+script = ExtResource("6_gadget_icon")
+gadget = 2
+
+[node name="KeyHint" type="Panel" parent="GadgetWidget"]
+visible = false
+offset_left = 66.0
+offset_top = 94.0
+offset_right = 94.0
+offset_bottom = 122.0
+mouse_filter = 2
+theme_override_styles/panel = SubResource("sb_gadget_keyhint")
+
+[node name="KeyLabel" type="Label" parent="GadgetWidget/KeyHint"]
+anchor_right = 1.0
+anchor_bottom = 1.0
+mouse_filter = 2
+theme_override_colors/font_color = Color(0.1, 0.08, 0.02, 1)
+theme_override_font_sizes/font_size = 16
+text = "Q"
+horizontal_alignment = 1
+vertical_alignment = 1
+
+[node name="NameLabel" type="Label" parent="GadgetWidget"]
+offset_left = -8.0
+offset_top = 126.0
+offset_right = 108.0
+offset_bottom = 150.0
+mouse_filter = 2
+theme_override_colors/font_color = Color(0.96, 0.97, 1, 1)
+theme_override_colors/font_outline_color = Color(0.05, 0.06, 0.1, 1)
+theme_override_constants/outline_size = 5
+theme_override_font_sizes/font_size = 15
+text = "Airstrike"
+horizontal_alignment = 1
+
+[node name="VoicelineLabel" type="Label" parent="."]
+anchor_right = 1.0
+offset_top = 40.0
+offset_bottom = 80.0
+mouse_filter = 2
+theme_override_colors/font_color = Color(0.96, 0.74, 0.12, 1)
+theme_override_colors/font_outline_color = Color(0.05, 0.06, 0.1, 1)
+theme_override_constants/outline_size = 6
+theme_override_font_sizes/font_size = 22
+text = ""
+horizontal_alignment = 1
+vertical_alignment = 1
 
 [connection signal="pressed" from="VBoxContainer/TakeDamageButton" to="." method="_on_take_damage_pressed"]


### PR DESCRIPTION
…weapon hotbar

Gadgets charge passively and are used with Q / cycled with G. HUD gadget tile sits bottom-right so it does not overlap the centered weapon hotbar or top-left health. Dice has its own weighted outcome pool (Heal, Teleport-to-cursor, Shockwave, Swap, Jackpot, Snake Eyes) shown via a slot-machine reel with per-outcome icons; the roll locks until used. Includes code-drawn icons and impact VFX.

## Describe your changes
- What does this PR add or fix?
- How did you test and validate your changes?

## Dev Checklist
- [ ] Scene runs without errors and achieves intended goal.
- [ ] All `res://` paths are relative; no absolute OS paths.

Close #<issue-id>