### PR TITLE
Creation Submenu on Create Lobby

### DIFF
--- a/Assets/Scripts/UI/level_menu.gd
+++ b/Assets/Scripts/UI/level_menu.gd
@@ -1,0 +1,33 @@
+extends Control
+
+signal back
+signal level_selected(level_path: String)
+
+const LEVELS := {
+	"Level01": "res://src/scenes/level01.tscn",
+	"Level02": "res://src/scenes/Level02/level02.tscn",
+	"Level03": "res://src/scenes/Level03/level03.tscn",
+}
+
+
+func _ready() -> void:
+	visible = false
+	$Center/Panel/Margin/Layout/LevelList/Level01.pressed.connect(_on_level_pressed.bind("Level01"))
+	$Center/Panel/Margin/Layout/LevelList/Level02.pressed.connect(_on_level_pressed.bind("Level02"))
+	$Center/Panel/Margin/Layout/LevelList/Level03.pressed.connect(_on_level_pressed.bind("Level03"))
+	$Center/Panel/Margin/Layout/Footer/Back.pressed.connect(_on_back)
+
+
+func open() -> void:
+	visible = true
+	$Center/Panel/Margin/Layout/LevelList/Level01.grab_focus()
+
+
+func _on_level_pressed(level_key: String) -> void:
+	visible = false
+	level_selected.emit(LEVELS[level_key])
+
+
+func _on_back() -> void:
+	visible = false
+	back.emit()

--- a/Assets/Scripts/UI/level_menu.gd.uid
+++ b/Assets/Scripts/UI/level_menu.gd.uid
@@ -1,0 +1,1 @@
+uid://3nsvwe1fcwhw

--- a/Assets/Scripts/UI/main_menu.gd
+++ b/Assets/Scripts/UI/main_menu.gd
@@ -5,6 +5,7 @@ const QUICK_JOIN_SCENE := "res://src/scenes/level01.tscn"
 @onready var loadout_menu: Control = $LoadoutMenu
 @onready var profile_menu: Control = $ProfileMenu
 @onready var lobby_list: Control = $LobbyList
+@onready var level_menu: Control = $LevelMenu
 
 var _main_controls: Array[CanvasItem]
 
@@ -22,6 +23,7 @@ func _ready() -> void:
 	]
 	$Loadout_Button.pressed.connect(_open_loadout)
 	$Level_Button.pressed.connect(_open_profile)
+	$Create_Button.pressed.connect(_open_level_menu)
 	$Join_Button.pressed.connect(_open_lobby_list)
 	$Quick_Button.pressed.connect(_quick_join)
 	$Quit_Button.pressed.connect(_quit_game)
@@ -32,6 +34,8 @@ func _ready() -> void:
 	profile_menu.loadout_requested.connect(_open_loadout)
 	lobby_list.back.connect(_close_lobby_list)
 	lobby_list.join_requested.connect(_quick_join)
+	level_menu.back.connect(_close_level_menu)
+	level_menu.level_selected.connect(_on_level_selected)
 	loadout_menu.visible = false
 
 
@@ -76,6 +80,21 @@ func _close_lobby_list() -> void:
 	lobby_list.visible = false
 	_set_main_controls_visible(true)
 	$Join_Button.grab_focus()
+
+
+func _open_level_menu() -> void:
+	_set_main_controls_visible(false)
+	level_menu.open()
+
+
+func _close_level_menu() -> void:
+	level_menu.visible = false
+	_set_main_controls_visible(true)
+	$Create_Button.grab_focus()
+
+
+func _on_level_selected(level_path: String) -> void:
+	get_tree().change_scene_to_file(level_path)
 
 
 func _set_main_controls_visible(is_visible: bool) -> void:

--- a/Main_Menu.tscn
+++ b/Main_Menu.tscn
@@ -8,6 +8,7 @@
 [ext_resource type="PackedScene" path="res://src/scenes/ui/loadout_menu.tscn" id="6_loadout"]
 [ext_resource type="PackedScene" path="res://src/scenes/ui/profile_menu.tscn" id="7_profile"]
 [ext_resource type="PackedScene" path="res://src/scenes/ui/lobby_list.tscn" id="8_lobby"]
+[ext_resource type="PackedScene" path="res://src/scenes/ui/level_menu.tscn" id="9_level"]
 
 [node name="Control" type="Control" unique_id=251354884]
 layout_mode = 3
@@ -110,3 +111,5 @@ autoplay = true
 [node name="ProfileMenu" parent="." instance=ExtResource("7_profile")]
 
 [node name="LobbyList" parent="." instance=ExtResource("8_lobby")]
+
+[node name="LevelMenu" parent="." instance=ExtResource("9_level")]

--- a/src/scenes/ui/level_menu.tscn
+++ b/src/scenes/ui/level_menu.tscn
@@ -1,0 +1,111 @@
+[gd_scene load_steps=5 format=3]
+
+[ext_resource type="Script" path="res://Assets/Scripts/UI/level_menu.gd" id="1_script"]
+[ext_resource type="FontFile" uid="uid://e377swnyfu56" path="res://Assets/fonts/alagard/alagard.ttf" id="2_font"]
+
+[sub_resource type="StyleBoxFlat" id="PanelStyle"]
+bg_color = Color(0.08, 0.09, 0.13, 0.98)
+border_width_left = 3
+border_width_top = 3
+border_width_right = 3
+border_width_bottom = 3
+border_color = Color(0.78, 0.31, 0.56, 1)
+corner_radius_top_left = 18
+corner_radius_top_right = 18
+corner_radius_bottom_right = 18
+corner_radius_bottom_left = 18
+
+[sub_resource type="StyleBoxFlat" id="ItemStyle"]
+bg_color = Color(0.09, 0.1, 0.15, 1)
+corner_radius_top_left = 6
+corner_radius_top_right = 6
+corner_radius_bottom_right = 6
+corner_radius_bottom_left = 6
+
+[node name="LevelMenu" type="Control"]
+visible = false
+layout_mode = 3
+anchors_preset = 15
+anchor_right = 1.0
+anchor_bottom = 1.0
+grow_horizontal = 2
+grow_vertical = 2
+mouse_filter = 0
+script = ExtResource("1_script")
+
+[node name="Dim" type="ColorRect" parent="."]
+layout_mode = 1
+anchors_preset = 15
+anchor_right = 1.0
+anchor_bottom = 1.0
+grow_horizontal = 2
+grow_vertical = 2
+color = Color(0.015, 0.018, 0.03, 0.82)
+
+[node name="Center" type="CenterContainer" parent="."]
+layout_mode = 1
+anchors_preset = 15
+anchor_right = 1.0
+anchor_bottom = 1.0
+offset_left = 32.0
+offset_top = 28.0
+offset_right = -32.0
+offset_bottom = -28.0
+grow_horizontal = 2
+grow_vertical = 2
+
+[node name="Panel" type="PanelContainer" parent="Center"]
+custom_minimum_size = Vector2(520, 460)
+layout_mode = 2
+theme_override_styles/panel = SubResource("PanelStyle")
+
+[node name="Margin" type="MarginContainer" parent="Center/Panel"]
+layout_mode = 2
+theme_override_constants/margin_left = 28
+theme_override_constants/margin_top = 22
+theme_override_constants/margin_right = 28
+theme_override_constants/margin_bottom = 22
+
+[node name="Layout" type="VBoxContainer" parent="Center/Panel/Margin"]
+layout_mode = 2
+theme_override_constants/separation = 16
+
+[node name="Title" type="Label" parent="Center/Panel/Margin/Layout"]
+layout_mode = 2
+theme_override_colors/font_color = Color(0.96, 0.74, 0.12, 1)
+theme_override_fonts/font = ExtResource("2_font")
+theme_override_font_sizes/font_size = 36
+text = "SELECT LEVEL"
+horizontal_alignment = 1
+
+[node name="LevelList" type="VBoxContainer" parent="Center/Panel/Margin/Layout"]
+layout_mode = 2
+size_flags_vertical = 3
+theme_override_constants/separation = 10
+
+[node name="Level01" type="Button" parent="Center/Panel/Margin/Layout/LevelList"]
+custom_minimum_size = Vector2(0, 56)
+layout_mode = 2
+theme_override_styles/normal = SubResource("ItemStyle")
+text = "LEVEL 01"
+
+[node name="Level02" type="Button" parent="Center/Panel/Margin/Layout/LevelList"]
+custom_minimum_size = Vector2(0, 56)
+layout_mode = 2
+theme_override_styles/normal = SubResource("ItemStyle")
+text = "LEVEL 02"
+
+[node name="Level03" type="Button" parent="Center/Panel/Margin/Layout/LevelList"]
+custom_minimum_size = Vector2(0, 56)
+layout_mode = 2
+theme_override_styles/normal = SubResource("ItemStyle")
+text = "LEVEL 03"
+
+[node name="Footer" type="HBoxContainer" parent="Center/Panel/Margin/Layout"]
+layout_mode = 2
+alignment = 2
+
+[node name="Back" type="Button" parent="Center/Panel/Margin/Layout/Footer"]
+custom_minimum_size = Vector2(140, 42)
+layout_mode = 2
+text = "BACK TO MENU"


### PR DESCRIPTION
## Describe your changes
- Adds a new LevelMenu submenu, opened by pressing "Create Lobby" on the main menu, letting the player pick Level
  01–03 before loading it.
- New files: `Assets/Scripts/UI/level_menu.gd`, `src/scenes/ui/level_menu.tscn`.
- `main_menu.gd` / `Main_Menu.tscn` updated to wire the Create Lobby button to open/close the level menu.
- How tested: Manually in Godot — opened the level menu via Create Lobby, selected each level, verified Back returns
  to the main menu.

  ## Dev Checklist
  - [x] Scene runs without errors and achieves intended goal.
  - [x] All `res://` paths are relative; no absolute OS paths

Close #129 >