### PR TITLE
Bug described in issue #139 fixed, plus added "Return to Menu" key "L…

### DIFF
--- a/Assets/Scripts/Levels/base_level.gd
+++ b/Assets/Scripts/Levels/base_level.gd
@@ -24,7 +24,6 @@ func _ready() -> void:
 	_prepare_level()
 	_register_spawn_points()
 	_connect_death_zone()
-	_assign_local_player()
 
 
 ## Leaving a match works the same way from every arena, so it lives here rather
@@ -99,17 +98,3 @@ func _connect_death_zone() -> void:
 func _on_death_zone_body_entered(body: Node2D) -> void:
 	if body.has_method("die") and not body.get("_is_dead"):
 		body.die()
-
-
-## Marks the first character in the scene as the one the local player sees
-## and controls; every other character stops reacting to input until
-## something else drives it (AI, or eventually a remote peer). This is a
-## placeholder for real multiplayer authority: once networking exists,
-## replace the spawn-order check below with each character's
-## [code]is_multiplayer_authority()[/code].
-func _assign_local_player() -> void:
-	var assigned := false
-	for child in get_children():
-		if child is CharacterBody2D and child.has_method("set_is_local_player"):
-			child.set_is_local_player(not assigned)
-			assigned = true

--- a/Assets/Scripts/Levels/level02.gd
+++ b/Assets/Scripts/Levels/level02.gd
@@ -1,0 +1,6 @@
+extends BaseLevel
+## The second hand built arena.
+##
+## Spawn points, the death zone and the respawn hand-off all come from
+## [BaseLevel]; this level only exists as its own script so level specific
+## scripting has an obvious home.

--- a/Assets/Scripts/Levels/level02.gd.uid
+++ b/Assets/Scripts/Levels/level02.gd.uid
@@ -1,0 +1,1 @@
+uid://doyrksbg0s61g

--- a/Assets/Scripts/character.gd
+++ b/Assets/Scripts/character.gd
@@ -3,12 +3,12 @@ extends CharacterBody2D
 @onready var hud = $HUD # The HUD node
 @onready var _camera: Camera2D = $Camera2D
 ## Whether this instance is the one the local player sees and controls.
-## Non-local instances (currently: every character after the first one
-## BaseLevel finds) keep their camera off, their HUD hidden and ignore
+## Set automatically in _ready(): the first character to join the "Players"
+## group each level (or test) counts as local, every one after it doesn't.
+## Non-local instances keep their camera off, their HUD hidden and ignore
 ## input, so only one character reacts to the keyboard at a time. This is a
 ## placeholder for real multiplayer authority - once networking exists,
-## BaseLevel should assign this from is_multiplayer_authority() instead of
-## spawn order. Defaults to true so isolated scenes/tests behave normally.
+## replace the group-order check in _ready() with is_multiplayer_authority().
 @export var is_local_player: bool = true
 @export var speed: float = 200.0
 @export var jump_velocity: float = -500.0
@@ -57,6 +57,9 @@ var is_dashing: bool = false
 
 func _ready() -> void:
 	add_to_group("Players")
+	# First character to join "Players" this level is the local player;
+	# every one after it (group already has other members) is not.
+	is_local_player = get_tree().get_nodes_in_group("Players").size() == 1
 	current_health = max_health
 	_sprite = $AnimatedSprite2D
 	_shotgun = $BasisWeapon

--- a/src/scenes/Level02/level02.tscn
+++ b/src/scenes/Level02/level02.tscn
@@ -2,8 +2,10 @@
 
 [ext_resource type="PackedScene" uid="uid://bu2t6avjf6485" path="res://src/scenes/Tilemap.tscn" id="3_7si7p"]
 [ext_resource type="PackedScene" uid="uid://2wp52upgfki3" path="res://src/scenes/player.tscn" id="5_x4wxc"]
+[ext_resource type="Script" path="res://Assets/Scripts/Levels/level02.gd" id="6_level"]
 
 [node name="Level02" type="Node2D" unique_id=1131213286]
+script = ExtResource("6_level")
 
 [node name="Tilemap" parent="." unique_id=547437705 instance=ExtResource("3_7si7p")]
 position = Vector2(237, 35)


### PR DESCRIPTION
 What does this PR do?
  Adds level02.gd (extends BaseLevel) and wires it into level02.tscn's
  root node, which had no script attached at all. Also moves the
  local-player assignment out of BaseLevel and into character.gd's own
  _ready(): the first character to join the "Players" group each level
  counts as local, every one after it doesn't. No level needs to call
  anything for this to work anymore.

  Why is this change necessary?
  Concerns Issue #139. Level02 never extended BaseLevel, so the enemy
  kept reacting to the player's keyboard input there (and the
  return-to-menu shortcut never worked either). The previous assignment
  also only ran because BaseLevel explicitly called it, so every future
  level would have needed the same wiring to avoid repeating this bug.

  How was this tested?
  Tested manually in Godot - Level02's enemy no longer moves with the
  player. Also verified headlessly that Level01, Level02 and Level03
  all load without errors under the new self-assignment logic.

## Dev Checklist
- [x] Scene runs without errors and achieves intended goal.
- [x] All `res://` paths are relative; no absolute OS paths.

Close #<issue-id>